### PR TITLE
modify requirement

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,9 +1,9 @@
 # The following contains only Python package dependencies
 
+Cython>=0.28.5
 Django>=1.11.7
 thulac>=0.1.2
 py2neo==4.1.0
 pyfasttext==0.4.5
 pinyin>=0.4.0
 pymongo>=3.6.1
-Cython>=0.28.5


### PR DESCRIPTION
原来的requirement的顺序不对，应该先安装cython，不然会在安装pyfasttext的时候出问题，这个依赖cython